### PR TITLE
Add DM support and developer fallback for Amazon links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,15 @@
 DISCORD_TOKEN=token_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DATABASE_URL=sqlite://./bot.db
+
+# Default Tracking IDs for developer compensation (used in DMs and when no server config exists)
+DEFAULT_TRACKING_TAG_DE=developer-tag-21
+DEFAULT_TRACKING_TAG_COM=developer-tag-20
+DEFAULT_TRACKING_TAG_CO_UK=developer-tag-21
+DEFAULT_TRACKING_TAG_FR=developer-tag-21
+DEFAULT_TRACKING_TAG_IT=developer-tag-21
+DEFAULT_TRACKING_TAG_ES=developer-tag-21
+DEFAULT_TRACKING_TAG_CO_JP=developer-tag-22
+DEFAULT_TRACKING_TAG_CA=developer-tag-20
+
+# Default signature for DMs and fallback scenarios
+DEFAULT_SIGNATURE="🤖 Powered by Affilify Bot - Supporting developers worldwide!"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 
 * **Affiliate-Link Cleaning & Tagging**: Normalize any Amazon URL (including short links) to a clean `https://amazon.{region}/dp/{ASIN}/?tag={tracking_tag}` format.
 * **Short-URL Resolution**: Follows redirects for `amzn.to`, `amzn.eu`, etc.
+* **User Install Support**: Works both as server bot and user installation for DMs.
 * **Per-Server Configuration**: Admins or server owners can set affiliate tags and custom footer templates via `/configure`.
+* **Developer Fallback System**: Uses default developer tracking tags when no server configuration exists, ensuring fair compensation.
 * **Custom Footer**: Supports a `{{sender}}` placeholder or defaults to `@user recommended this…`.
 * **Usage Statistics**: Logs every `/amazon` invocation and exposes global & per-guild counts via `/stats`.
 * **Automatic Hint**: Raw Amazon links in chat are deleted and the user is pinged with a temporary hint to use `/amazon`.
@@ -40,10 +42,11 @@
 git clone https://github.com/bnfone/discord-bot-affilify.git
 cd discord-bot-affilify
 
-# Copy example env and fill in your token
+# Copy example env and configure your bot
 cp .env.example .env
-# Ensure DATABASE_URL points to a file path
-# e.g. DATABASE_URL=./bot.db
+# Edit .env and set your DISCORD_TOKEN
+# Configure default tracking IDs for each Amazon region
+# Set your preferred DEFAULT_SIGNATURE for DMs
 
 # Create the SQLite file before running
 touch bot.db
@@ -62,6 +65,10 @@ In the Discord Developer Portal, under your Bot settings:
 * **OAuth2 Scopes**:
 
   * `bot`, `applications.commands`
+* **Installation Types** (for User Install support):
+
+  * **Guild Install** (traditional server installation)
+  * **User Install** (personal bot access in DMs)
 * **Bot Permissions** (when adding to your server):
 
   * **Read Messages & History**
@@ -71,17 +78,24 @@ In the Discord Developer Portal, under your Bot settings:
 
 ### 3. Slash Commands
 
-* `/configure region:<code> tag:<your-tag> [footer:<text>]` — Set your affiliate tag and optional custom footer.
-* `/amazon url:<link>` — Clean & tag your Amazon link.
-* `/stats` — Show total and per-server link counts.
+* `/configure region:<code> tag:<your-tag> [footer:<text>]` — Set your affiliate tag and optional custom footer (Server only)
+* `/amazon url:<link>` — Clean & tag your Amazon link (Works in servers and DMs)
+* `/stats` — Show total and per-server link counts
 
-Example:
+**Usage Examples:**
 
 ```
+# Server configuration (admin only)
 /configure region: de tag: mytag-21 footer: "{{sender}} recommended this and supports us!"
+
+# Link cleaning (works everywhere)
 /amazon https://amzn.to/xyz123
+
+# Statistics
 /stats
 ```
+
+**DM Usage:** When used in Direct Messages, the bot automatically uses your configured default tracking tags and signature, ensuring you get compensated for unconfigured usage.
 
 ---
 
@@ -136,8 +150,69 @@ Register it under `.github/workflows/docker-multiarch.yml` to automatically publ
 
 ## 🔐 Configuration & Data
 
-* **`.env`-file**: store `DISCORD_TOKEN` and `DATABASE_URL`.
+### Environment Variables
+
+The `.env` file supports the following configuration:
+
+```env
+# Required
+DISCORD_TOKEN=your_bot_token_here
+DATABASE_URL=sqlite://./bot.db
+
+# Default tracking tags for developer compensation
+DEFAULT_TRACKING_TAG_DE=your-tag-21      # Germany
+DEFAULT_TRACKING_TAG_COM=your-tag-20     # United States
+DEFAULT_TRACKING_TAG_CO_UK=your-tag-21   # United Kingdom
+DEFAULT_TRACKING_TAG_FR=your-tag-21      # France
+DEFAULT_TRACKING_TAG_IT=your-tag-21      # Italy
+DEFAULT_TRACKING_TAG_ES=your-tag-21      # Spain
+DEFAULT_TRACKING_TAG_CO_JP=your-tag-22   # Japan
+DEFAULT_TRACKING_TAG_CA=your-tag-20      # Canada
+
+# Default signature for DMs and fallback
+DEFAULT_SIGNATURE="🤖 Powered by Affilify Bot - Supporting developers worldwide!"
+```
+
+### Database
+
 * **SQLite DB**: the file referenced by `DATABASE_URL` **must exist** before the bot starts, or create it with `touch bot.db`.
+* The bot automatically creates the necessary tables on first run.
+
+---
+
+## 📄 Changelog
+
+### Version 2.0.0 - User Install & Developer Fallback Support
+
+#### 🆕 New Features
+- **User Install Support**: Bot now works as both server installation and user installation for DMs
+- **Developer Fallback System**: Automatic fallback to developer tracking tags when no server configuration exists
+- **DM Support**: Full functionality in Direct Messages with developer compensation
+- **Configurable Defaults**: Environment-based default tracking tags and signatures for all Amazon regions
+- **Smart Context Detection**: Bot automatically detects DM vs server context and adjusts behavior accordingly
+
+#### 🔧 Technical Changes
+- Added `DIRECT_MESSAGES` gateway intent for DM support
+- Enhanced `amazon.rs` with DM detection and fallback logic
+- New configuration functions in `config.rs` for default tracking tags and signatures
+- Updated `.env.example` with comprehensive default tracking configuration for 8 Amazon regions
+- Fixed emoji parsing in environment variables (proper quoting required)
+- Improved error handling for missing configuration scenarios
+
+#### 🐛 Bug Fixes
+- Fixed `.env` parsing error with special characters in `DEFAULT_SIGNATURE`
+- Added proper string quoting for environment variables containing emojis or special characters
+
+#### 💡 Benefits
+- **Fair Developer Compensation**: Ensures developers get paid even when bot isn't configured on servers
+- **Enhanced User Experience**: Seamless functionality across servers and DMs
+- **Reduced Configuration Overhead**: Works out-of-the-box with sensible defaults
+- **Global Amazon Support**: Pre-configured for major Amazon marketplaces worldwide
+
+#### 🔄 Migration Notes
+- **Breaking Change**: `.env` format updated - check `.env.example` for new required variables
+- Users upgrading should update their `.env` file with new `DEFAULT_TRACKING_TAG_*` and `DEFAULT_SIGNATURE` variables
+- Existing server configurations remain unchanged and take priority over defaults
 
 ---
 

--- a/src/commands/amazon.rs
+++ b/src/commands/amazon.rs
@@ -7,7 +7,7 @@ use serenity::model::application::interaction::application_command::{Application
 use serenity::model::application::interaction::InteractionResponseType;
 use serenity::prelude::*;
 use rusqlite::params;
-use super::super::{db, utils};
+use super::super::{db, utils, config};
 
 /// Register the `/amazon` slash command with a URL option.
 pub async fn register_commands(http: &Http) {
@@ -31,8 +31,9 @@ pub async fn register_commands(http: &Http) {
 /// - Logs usage in the database
 /// - Replies with a plain message: cleaned link + footer
 pub async fn run(ctx: &Context, cmd: &ApplicationCommandInteraction) {
-    // Guild ID as string
-    let guild_id = cmd.guild_id.unwrap().0.to_string();
+    // Check if this is a DM or Guild interaction
+    let is_dm = cmd.guild_id.is_none();
+    let guild_id = cmd.guild_id.map(|id| id.0.to_string()).unwrap_or_else(|| "DM".to_string());
 
     // Extract raw URL argument
     let url_raw = if let CommandDataOptionValue::String(u) = &cmd.data.options[0].resolved.as_ref().unwrap() {
@@ -46,33 +47,50 @@ pub async fn run(ctx: &Context, cmd: &ApplicationCommandInteraction) {
 
     // Parse ASIN and region
     if let Some((asin, region)) = utils::parse_amazon_url(&resolved) {
-        // Default footer template
-        let default_template = "Using this link you support our server!".to_string();
-
-        // Fetch tracking tag and footer template
-        let (tag, footer_template) = db::with_connection(|conn| {
-            let tag: String = conn.query_row(
-                "SELECT tracking_tag FROM guild_affiliates WHERE guild_id = ? AND region = ?",
-                params![guild_id, region],
-                |r| r.get(0),
-            )?;
-            let footer: String = conn.query_row(
-                    "SELECT footer_text FROM guild_settings WHERE guild_id = ?",
-                    params![guild_id],
+        // Determine tracking tag and footer based on context (DM vs Guild)
+        let (tag, footer_template) = if is_dm {
+            // Use default developer tags and signature for DMs
+            let default_tag = config::default_tracking_tag(&region);
+            let default_signature = config::default_signature();
+            (default_tag, default_signature)
+        } else {
+            // Try to get guild-specific settings, fallback to defaults
+            let default_template = "Using this link you support our server!".to_string();
+            
+            let (guild_tag, guild_footer) = db::with_connection(|conn| {
+                let tag: String = conn.query_row(
+                    "SELECT tracking_tag FROM guild_affiliates WHERE guild_id = ? AND region = ?",
+                    params![guild_id, region],
                     |r| r.get(0),
-                )
-                .unwrap_or_else(|_| default_template.clone());
-            Ok((tag, footer))
-        })
-        .unwrap_or((String::new(), default_template.clone()));
+                ).unwrap_or_else(|_| String::new());
+                
+                let footer: String = conn.query_row(
+                        "SELECT footer_text FROM guild_settings WHERE guild_id = ?",
+                        params![guild_id],
+                        |r| r.get(0),
+                    )
+                    .unwrap_or_else(|_| default_template.clone());
+                Ok((tag, footer))
+            })
+            .unwrap_or((String::new(), default_template.clone()));
+            
+            // If no guild tag configured, use default developer tag
+            if guild_tag.is_empty() {
+                let default_tag = config::default_tracking_tag(&region);
+                let default_signature = config::default_signature();
+                (default_tag, default_signature)
+            } else {
+                (guild_tag, guild_footer)
+            }
+        };
 
-        // If no tag configured, inform user
+        // If still no tag available, inform user
         if tag.is_empty() {
             let _ = cmd
                 .create_interaction_response(&ctx.http, |resp|
                     resp.kind(InteractionResponseType::ChannelMessageWithSource)
                         .interaction_response_data(|m| m.content(
-                            "No tracking tag configured for this region. Ask an admin to run `/configure`."
+                            "No tracking tag available for this region."
                         )))
                 .await;
             return;
@@ -89,12 +107,16 @@ pub async fn run(ctx: &Context, cmd: &ApplicationCommandInteraction) {
         // Build cleaned URL
         let clean_url = format!("https://amazon.{}/dp/{}/?tag={}", region, asin, tag);
 
-        // Construct footer with sender mention support
-        let sender_mention = format!("<@{}>", cmd.user.id.0);
-        let footer = if footer_template.contains("{{sender}}") {
-            footer_template.replace("{{sender}}", &sender_mention)
+        // Construct footer with sender mention support (only in guilds, not DMs)
+        let footer = if is_dm {
+            footer_template
         } else {
-            format!("{} recommended this. {}", sender_mention, footer_template)
+            let sender_mention = format!("<@{}>", cmd.user.id.0);
+            if footer_template.contains("{{sender}}") {
+                footer_template.replace("{{sender}}", &sender_mention)
+            } else {
+                format!("{} recommended this. {}", sender_mention, footer_template)
+            }
         };
 
         // Send plain message: link + "-# footer"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,3 +15,12 @@ pub fn database_url() -> String {
     let raw = std::env::var("DATABASE_URL").unwrap_or_else(|_| "./bot.db".into());
     raw.strip_prefix("sqlite://").unwrap_or(&raw).to_string()
 }
+
+pub fn default_tracking_tag(region: &str) -> String {
+    let key = format!("DEFAULT_TRACKING_TAG_{}", region.to_uppercase().replace(".", "_"));
+    env::var(&key).unwrap_or_else(|_| String::new())
+}
+
+pub fn default_signature() -> String {
+    env::var("DEFAULT_SIGNATURE").unwrap_or_else(|_| "🤖 Powered by Affilify Bot".to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,9 +81,10 @@ async fn main() {
     db::init().expect("Failed to initialize database");
     // Retrieve Discord token from environment
     let token = config::discord_token();
-    // Define the necessary gateway intents
+    // Define the necessary gateway intents (including DM support)
     let intents = GatewayIntents::GUILDS
         | GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
     // Build the client
     let mut client = Client::builder(&token, intents)


### PR DESCRIPTION
Introduces user install (DM) support and a developer fallback system for Amazon affiliate links. The bot now uses default tracking tags and signatures from environment variables when no server configuration exists, ensuring fair developer compensation. Updates .env.example and README with new configuration options, enhances amazon.rs to detect DM context, and adds config.rs helpers for default values. Also updates gateway intents to include DIRECT_MESSAGES.